### PR TITLE
PCA minRowSum now checks only the samples selected to be used. 

### DIFF
--- a/R/qsea.plots.R
+++ b/R/qsea.plots.R
@@ -5,15 +5,16 @@
 
 getPCA<-function(qs, chr=getChrNames(qs),ROIs, minRowSum=20, keep,norm_method=
         normMethod(logRPM=c("log", "library_size","cnv","preference","psC10")),
-        topVar=1000, samples=getSampleNames(qs)){
-    
+        topVar=1000, samples=getSampleNames(qs), minEnrichment=0){
+
     if(is.null(samples))
         samples=    getSampleNames(qs)
     samples=checkSamples(qs, samples)
-    if(missing(keep)) 
-        keep=which(rowSums(getCounts(qs)) >= minRowSum )
+
+    if(missing(keep))
+        keep=which(rowSums(getCounts(qs, samples=samples)) >= minRowSum )
     else
-        keep=intersect(keep, which(rowSums(getCounts(qs)) >= minRowSum ))
+        keep=intersect(keep, which(rowSums(getCounts(qs, samples=samples)) >= minRowSum ))
     if(is(norm_method,"character")){
         norm_method=normMethod(norm_method)
     }
@@ -29,8 +30,8 @@ getPCA<-function(qs, chr=getChrNames(qs),ROIs, minRowSum=20, keep,norm_method=
     if(length(keep)<=10){
         stop("not enough regions left:",length(keep)," Regions, minimum is 10")
     }
-    vals=getNormalizedValues(qs,methods=norm_method, 
-        windows=keep, samples=samples)
+    vals=getNormalizedValues(qs,methods=norm_method,
+        windows=keep, samples=samples, minEnrichment=minEnrichment)
     missing=rowSums(is.na(vals))>0
     vals=vals[!missing,]-rowMeans(vals[!missing,])
     if(any(!is.finite(vals))){
@@ -55,18 +56,18 @@ getPCA<-function(qs, chr=getChrNames(qs),ROIs, minRowSum=20, keep,norm_method=
             names=do.call(mapply,c(as.list(mcols(ROIs[m])),FUN=paste,
                 MoreArgs = list(sep="_")))
     }else{
-        names=paste0(seqnames(getRegions(qs)[keep]), ":", 
+        names=paste0(seqnames(getRegions(qs)[keep]), ":",
             start(getRegions(qs)[keep]), "-", end(getRegions(qs)[keep]))
     }
 
     svdVals=svd(vals)
-    new('qseaPCA', svd=svdVals, sample_names=samples, 
+    new('qseaPCA', svd=svdVals, sample_names=samples,
         factor_names=as.character(names))
 }
-        
-plotPCA.qsea=function(object,plotComponents=c(1,2), fgColor="black", 
-        bgColor="white", legend=NULL, plotLabels=TRUE, radius=5, 
-        labelOffset=.5,labelPos=1, labelAdj=NULL, labelColor="black", 
+
+plotPCA.qsea=function(object,plotComponents=c(1,2), fgColor="black",
+        bgColor="white", legend=NULL, plotLabels=TRUE, radius=5,
+        labelOffset=.5,labelPos=1, labelAdj=NULL, labelColor="black",
         cex=1, ...) {
     pca=object
     pc1=plotComponents[1]
@@ -76,13 +77,13 @@ plotPCA.qsea=function(object,plotComponents=c(1,2), fgColor="black",
     if(length(radius)==1) radius=rep(radius, n)
     x=svd$v[,pc1]*svd$d[pc1]
     y=svd$v[,pc2]*svd$d[pc2]
-    symbols(x=x, 
-        y=y, fg=fgColor,bg=bgColor, pch=20, 
+    symbols(x=x,
+        y=y, fg=fgColor,bg=bgColor, pch=20,
         xlab=paste0("PC",pc1), ylab=paste0("PC",pc2), circles=radius,
         inches=min(radius)/100 , ... )
     if(plotLabels)
-        text(svd$v[,pc1]*svd$d[pc1], svd$v[,pc2]*svd$d[pc2], 
-            label=getSampleNames(pca), pos=labelPos,adj=labelAdj, 
+        text(svd$v[,pc1]*svd$d[pc1], svd$v[,pc2]*svd$d[pc2],
+            label=getSampleNames(pca), pos=labelPos,adj=labelAdj,
             offset=labelOffset,col=labelColor, cex=cex)
     if(!is.null(legend))
         legend(x=legend, legend=getSampleNames(pca), fill=bgColor, cex=cex)
@@ -91,15 +92,15 @@ plotPCA.qsea=function(object,plotComponents=c(1,2), fgColor="black",
 }
 setMethod('plotPCA', signature(object='qseaPCA'), plotPCA.qsea)
 
-setGeneric('plotPCAfactors', function(object,...) 
+setGeneric('plotPCAfactors', function(object,...)
     standardGeneric('plotPCAfactors'))
 
-plotPCAfactors.qsea=function(object,plotComponents=c(1,2), fgColor="black", 
-        bgColor="white", plotTopLabels=100,labelsOfInterest,radius=1, 
+plotPCAfactors.qsea=function(object,plotComponents=c(1,2), fgColor="black",
+        bgColor="white", plotTopLabels=100,labelsOfInterest,radius=1,
         labelOffset=.5,labelPos=1,labelColor="black", cex=1 , ... ){
     pca=object
     pc1=plotComponents[1]
-    pc2=plotComponents[2]    
+    pc2=plotComponents[2]
     svd=getSVD(pca)
     n=nrow(svd$u)
     plotLabels=numeric(0)
@@ -117,10 +118,10 @@ plotPCAfactors.qsea=function(object,plotComponents=c(1,2), fgColor="black",
         }
     }
     if(length(radius)==1) radius=rep(radius, n)
-    symbols(x=x, y=y, fg=fgColor,bg=bgColor, pch=20, xlab=paste0("PC",pc1), 
+    symbols(x=x, y=y, fg=fgColor,bg=bgColor, pch=20, xlab=paste0("PC",pc1),
         ylab=paste0("PC",pc2), circles=radius, inches=min(radius)/100, ...)
     if(length(plotLabels)>0)
-        text(x=x[plotLabels], y=y[plotLabels], 
+        text(x=x[plotLabels], y=y[plotLabels],
             label=getFactorNames(pca)[plotLabels],pos=labelPos,
             offset=labelOffset, col=labelColor, cex=cex)
     invisible(list(x=x, y=y))
@@ -134,8 +135,8 @@ setMethod('plotPCAfactors', signature(object='qseaPCA'), plotPCAfactors.qsea)
 
 
 
-plotCNV<-function(qs, dist=c("euclid", "cor")[1], clust_method="complete", 
-    chr= getChrNames(qs), samples=getSampleNames(qs),cex=1, 
+plotCNV<-function(qs, dist=c("euclid", "cor")[1], clust_method="complete",
+    chr= getChrNames(qs), samples=getSampleNames(qs),cex=1,
     labels=c(TRUE,TRUE, TRUE, TRUE), naColor="darkgrey" , indicateLogFC=TRUE){
 
     if(missing(qs) | !is(qs, "qseaSet" ))
@@ -145,7 +146,7 @@ plotCNV<-function(qs, dist=c("euclid", "cor")[1], clust_method="complete",
     n=length(samples)
     samples=checkSamples(qs, samples)
 
-    colF=colorRamp(c("lightgreen","green", "darkgreen", "darkblue", "darkred", 
+    colF=colorRamp(c("lightgreen","green", "darkgreen", "darkblue", "darkred",
         "red", "orange"))
     tickpos=0
     chrorder=numeric(0)
@@ -177,7 +178,7 @@ plotCNV<-function(qs, dist=c("euclid", "cor")[1], clust_method="complete",
 
     #par( mai=c(3.1,2,2.1,1)/6 )
 
-    layout(matrix(c(1,1,2,3), 2, 2, byrow = TRUE), 
+    layout(matrix(c(1,1,2,3), 2, 2, byrow = TRUE),
         widths=c(1,4), heights=c(1,8))
     #plot(1,axes=FALSE,xlim=c(0,.1),xlab="", ylab="")
     sav=par(mar=c(2,1,2,1))
@@ -188,12 +189,12 @@ plotCNV<-function(qs, dist=c("euclid", "cor")[1], clust_method="complete",
     if(indicateLogFC){
         markAt=1
         if(lim<1) markAt=.5
-    
+
         text((markAt*c(-1,0,1)/lim+1)/2,c(.5,.5,.5),markAt*c(-1,0,1) , cex=cex)
     }
-    #values    
+    #values
     par( mar=c(3+2*cex*labels[1],2,2+2*cex*labels[3],1) )
-    
+
     plot(as.dendrogram(clust),horiz=TRUE,axes=FALSE,leaflab="none",yaxs="i")
     #image
     par( mar=c(3+2*cex*labels[1],
@@ -205,7 +206,7 @@ plotCNV<-function(qs, dist=c("euclid", "cor")[1], clust_method="complete",
         col=c(rgb(colF(0:40/40),maxColorValue=255),naColor))
     abline(v=tickpos)
     if(labels[1])
-        axis(side=1,labels=chr,at=chrpos,cex.axis=1,las=2, tick=FALSE, 
+        axis(side=1,labels=chr,at=chrpos,cex.axis=1,las=2, tick=FALSE,
             cex.axis=cex)
     axis(side=1,labels=rep("", length(tickpos)),at=tickpos,cex.axis=cex,
         las=2, tick=TRUE)
@@ -213,9 +214,9 @@ plotCNV<-function(qs, dist=c("euclid", "cor")[1], clust_method="complete",
         axis(side=2,labels=samples[clust$order],at=(seq_len(n)-1)/(n-1),
             cex.axis=cex,las=2)
     if(labels[3])
-        axis(side=3,labels=chr,at=chrpos,cex.axis=1,las=2, 
+        axis(side=3,labels=chr,at=chrpos,cex.axis=1,las=2,
             tick=FALSE, cex.axis=cex)
-    axis(side=3,labels=rep("", length(tickpos)),at=tickpos,cex.axis=cex,las=2, 
+    axis(side=3,labels=rep("", length(tickpos)),at=tickpos,cex.axis=cex,las=2,
             tick=TRUE)
     if(labels[4])
         axis(side=4,labels=samples[clust$order],at=(seq_len(n)-1)/(n-1),
@@ -229,16 +230,16 @@ plotCNV<-function(qs, dist=c("euclid", "cor")[1], clust_method="complete",
 ###########
 
 
-plotCoverage<-function(qs,test_results, chr, start, end, samples,samples2, 
-        norm_method="nrpkm", yoffset, xlab="Position", ylab="MeDIP seq", 
-        col="black", main, reorder="non", indicate_reorder=TRUE, distfun=dist, 
-        clustmethod="complete", scale=TRUE, steps=TRUE, space=0.05, 
-        baselines=TRUE, scale_val, scale_unit=NULL, logFC_pc=.1, cex=1, 
-        smooth_width, smooth_function=mean, regions, regions_lwd=1, 
+plotCoverage<-function(qs,test_results, chr, start, end, samples,samples2,
+        norm_method="nrpkm", yoffset, xlab="Position", ylab="MeDIP seq",
+        col="black", main, reorder="non", indicate_reorder=TRUE, distfun=dist,
+        clustmethod="complete", scale=TRUE, steps=TRUE, space=0.05,
+        baselines=TRUE, scale_val, scale_unit=NULL, logFC_pc=.1, cex=1,
+        smooth_width, smooth_function=mean, regions, regions_lwd=1,
         regions_col, regions_offset, regions_names, regions_dash=.1){
     if(missing(samples)) samples=getSampleNames(qs)
     samples=checkSamples(qs,samples)
-   
+
     if(! missing(regions)){
         if(! is(regions,"list")){
             regions=list(ROIs=regions)
@@ -246,7 +247,7 @@ plotCoverage<-function(qs,test_results, chr, start, end, samples,samples2,
         if(! all(sapply(regions, is, "GRanges"))){
             stop("\"regions\" should be a \"GenomicRanges\" object")
         }
-        if(missing(regions_lwd)) 
+        if(missing(regions_lwd))
             regions_lwd=list()
         if(! is(regions_lwd, "list")){
             regions_lwd=rep(list(regions_lwd), length(regions))
@@ -265,7 +266,7 @@ plotCoverage<-function(qs,test_results, chr, start, end, samples,samples2,
             names(regions_dash)=names(regions)
         }
         if( missing(regions_offset))
-            regions_offset=list()        
+            regions_offset=list()
         if (!is(regions_offset, "list")){
             regions_offset=rep(list(regions_offset), length(regions))
             names(regions_offset)=names(regions)
@@ -277,12 +278,12 @@ plotCoverage<-function(qs,test_results, chr, start, end, samples,samples2,
             names(regions_names)=names(regions)
         }
     }
-    if(length(col)<length(samples)) 
+    if(length(col)<length(samples))
         col=rep(col,ceiling(length(samples)/length(col) ))
     if(missing(main)) main=paste0(chr,":",start, "-", end)
     if(!missing(samples2)) {
         samples2=checkSamples(qs,samples2)
-        if(length(samples) != length(samples2) ) 
+        if(length(samples) != length(samples2) )
             stop("length(samples) != length(samples2)")
     }
     if(missing(test_results) && reorder=="minP")
@@ -294,10 +295,10 @@ plotCoverage<-function(qs,test_results, chr, start, end, samples,samples2,
 
     roi_tab=makeTable(qs=qs, samples=samples, minEnrichment=0,
         ROIs=GRanges(chr, ranges=IRanges(start, end)),norm_methods=norm_method)
-    ret=list(regions=roi_tab[,1:4])    
+    ret=list(regions=roi_tab[,1:4])
     roi_val=roi_tab[,grep(paste0("_",norm_method), names(roi_tab)), drop=FALSE]
     if(!missing(samples2)){
-        roi_tab2=makeTable(qs=qs, samples=samples2, 
+        roi_tab2=makeTable(qs=qs, samples=samples2,
             ROIs=GRanges(chr, ranges=IRanges(start, end)),
             norm_methods=norm_method)
         roi_val2=roi_tab2[,
@@ -311,9 +312,9 @@ plotCoverage<-function(qs,test_results, chr, start, end, samples,samples2,
     if(! missing(smooth_width)){
         message("smoothing values")
         for(i in seq_len(ncol(roi_val))){
-            roi_val[,i]=zoo::rollapply(data=roi_val[,i], 
+            roi_val[,i]=zoo::rollapply(data=roi_val[,i],
                 width=smooth_width, fill=0,FUN=smooth_function )
-        }        
+        }
     }
     ord=seq_along(samples)
     ordPos=NA
@@ -327,7 +328,7 @@ plotCoverage<-function(qs,test_results, chr, start, end, samples,samples2,
         ret$ordPos=(roi_tab$window_start[maxrow]+
             roi_tab$window_end[maxrow])/2
     }else if(reorder=="minP"){
-        test_tab=makeTable(qs, test_results, 
+        test_tab=makeTable(qs, test_results,
             ROIs=GRanges(chr, ranges=IRanges(start, end)))
         ret$regions=test_tab[,-(5:7)]
         minProw=which.min(test_tab[,grep("PValue", colnames(test_tab))])
@@ -341,7 +342,7 @@ plotCoverage<-function(qs,test_results, chr, start, end, samples,samples2,
             roi_tab$window_end[ordRow])/2
     }else if(reorder != "non"){
         warning("unknown reorder method")
-    }        
+    }
     roi_val=roi_val[,ord, drop=FALSE]
     col=col[ord]
 
@@ -374,27 +375,27 @@ plotCoverage<-function(qs,test_results, chr, start, end, samples,samples2,
                 regions[[reg_n]][
                     overlapsAny(regions[[reg_n]],
                     GRanges(chr, IRanges(start, end))) ]
-            if(!is.null(regions_names[[reg_n]]) && 
-                length(regions_names[[reg_n]])==1 && 
+            if(!is.null(regions_names[[reg_n]]) &&
+                length(regions_names[[reg_n]])==1 &&
                 regions_names[[reg_n]] %in% colnames(mcols(regions[[reg_n]])))
                     regions_names[[reg_n]]=
                         mcols(regions[[reg_n]])[,regions_names[[reg_n]]]
-            if(!is.null(regions_names[[reg_n]]) && 
+            if(!is.null(regions_names[[reg_n]]) &&
                 length(regions_names[[reg_n]])<length(regions[[reg_n]]) )
                     regions_names[[reg_n]]=
                         rep(regions_names[[reg_n]],
                             ceiling(length(regions[[reg_n]])/
                                 length(regions_names[[reg_n]]) ))
-            if(length(regions_col[[reg_n]])<length(regions[[reg_n]])) 
+            if(length(regions_col[[reg_n]])<length(regions[[reg_n]]))
                 regions_col[[reg_n]]=
                     rep(regions_col[[reg_n]],
                         ceiling(length(regions[[reg_n]])/
                             length(regions_col[[reg_n]]) ))
             reg_bins[[reg_n]]=
                 disjointBins(regions[[reg_n]], ignore.strand =TRUE)
-            if(is.null(regions_offset[[reg_n]])) 
+            if(is.null(regions_offset[[reg_n]]))
                 regions_offset[[reg_n]]=yoffset*1.5
-            if(length(regions[[reg_n]])>0)            
+            if(length(regions[[reg_n]])>0)
                 ylim[1]=ylim[1]-(max(reg_bins[[reg_n]])+1)*
                     regions_offset[[reg_n]]
             else
@@ -419,9 +420,9 @@ plotCoverage<-function(qs,test_results, chr, start, end, samples,samples2,
                 type="l", col="lightgrey", lty=4)
         points(xval, roi_val[,i, drop=FALSE], type="l", col=col[i])
     }
-    text(rep(xlim[1],n) + (xlim[2]-xlim[1])*(space-.01),(seq_len(n)-1)*yoffset, 
+    text(rep(xlim[1],n) + (xlim[2]-xlim[1])*(space-.01),(seq_len(n)-1)*yoffset,
         colnames(roi_val), col=col,adj = c(1, NA), cex=cex)
-    if(indicate_reorder && ! is.null(ret$ordPos)) 
+    if(indicate_reorder && ! is.null(ret$ordPos))
         arrows(ret$ordPos, 0, ret$ordPos, ylim[2]*.9, col="blue")
     if(!missing (regions)&& length(regions)>0){
         offsum=0
@@ -430,29 +431,29 @@ plotCoverage<-function(qs,test_results, chr, start, end, samples,samples2,
                 for(i in seq_along(regions[[reg_n]])){
                     ypos=offsum-regions_offset[[reg_n]]*reg_bins[[reg_n]][i]
                     points(c(start(regions[[reg_n]])[i],
-                        end(regions[[reg_n]])[i]), rep(ypos,2), 
-                        type="l", col=regions_col[[reg_n]][i], 
+                        end(regions[[reg_n]])[i]), rep(ypos,2),
+                        type="l", col=regions_col[[reg_n]][i],
                         lwd=regions_lwd[[reg_n]])
-                    if(! is.null(regions_dash[[reg_n]]) && 
+                    if(! is.null(regions_dash[[reg_n]]) &&
                         regions_dash[[reg_n]]>0){
                         points(c(start(regions[[reg_n]])[i],
-                            start(regions[[reg_n]])[i]), 
+                            start(regions[[reg_n]])[i]),
                             ypos+regions_offset[[reg_n]]*
-                                regions_dash[[reg_n]]*c(-1,1), 
-                            type="l", col=regions_col[[reg_n]][i], 
+                                regions_dash[[reg_n]]*c(-1,1),
+                            type="l", col=regions_col[[reg_n]][i],
                             lwd=regions_lwd[[reg_n]])
                         points(c( end(regions[[reg_n]])[i],
-                            end(regions[[reg_n]])[i]), 
+                            end(regions[[reg_n]])[i]),
                             ypos+regions_offset[[reg_n]]*
-                                regions_dash[[reg_n]]*c(-1,1), 
-                            type="l", col=regions_col[[reg_n]][i], 
+                                regions_dash[[reg_n]]*c(-1,1),
+                            type="l", col=regions_col[[reg_n]][i],
                             lwd=regions_lwd[[reg_n]])
                     }
-    
+
                 }
                 if(!is.null(regions_names[[reg_n]]) )
-                    text((start(regions[[reg_n]])+end(regions[[reg_n]]) )/2, 
-                        offsum-regions_offset[[reg_n]]*reg_bins[[reg_n]], 
+                    text((start(regions[[reg_n]])+end(regions[[reg_n]]) )/2,
+                        offsum-regions_offset[[reg_n]]*reg_bins[[reg_n]],
                         regions_names[[reg_n]] , adj=c(.5,1.2),
                         col=regions_col[[reg_n]], cex=cex)
                 off_roi=(max(reg_bins[[reg_n]])+1)*regions_offset[[reg_n]]
@@ -460,7 +461,7 @@ plotCoverage<-function(qs,test_results, chr, start, end, samples,samples2,
                 off_roi=regions_offset[[reg_n]]
             }
             message(reg_n)
-            text(xlim[1]+ (xlim[2]-xlim[1])*(space-.01),offsum-off_roi/2, 
+            text(xlim[1]+ (xlim[2]-xlim[1])*(space-.01),offsum-off_roi/2,
                 reg_n,col=regions_col[[reg_n]], adj=c(1,.5))
             offsum=offsum-off_roi
         }
@@ -468,7 +469,7 @@ plotCoverage<-function(qs,test_results, chr, start, end, samples,samples2,
     invisible(ret)
 }
 
-plotEnrichmentProfile<-function(qs,sample, sPoints=seq(0,30,1), 
+plotEnrichmentProfile<-function(qs,sample, sPoints=seq(0,30,1),
     fitPar=list(lty=2,col="green"),cfPar=list(lty=1),densityPar,meanPar,...){
     if(!hasEnrichment(qs))
         stop("no enrichment analysis found")
@@ -476,25 +477,25 @@ plotEnrichmentProfile<-function(qs,sample, sPoints=seq(0,30,1),
     if(missing(sample) || length(sample)!=1 )
         stop("please select one sample")
     plotPar=list(...)
-    defVal=list(xlab=paste(getEnrichmentPattern(qs),"density") , 
+    defVal=list(xlab=paste(getEnrichmentPattern(qs),"density") ,
         ylab="expected rpkm", main=sample)
     plotPar=c(plotPar, defVal[! names(defVal) %in% names(plotPar) ])
     if(is.null(plotPar$xlim))
         plotPar$xlim=range(sPoints)
     maxY=1
     recycle=c( "lty", "lwd", "col")
-    cfPar=c(cfPar, 
-    plotPar[(! names(plotPar) %in% names(cfPar)) & 
+    cfPar=c(cfPar,
+    plotPar[(! names(plotPar) %in% names(cfPar)) &
         names(plotPar) %in% recycle ])
     factors=getEnrichmentFactors(qs, sample)+getOffset(qs,sample,scale="rpkm")
     if(is.null(plotPar$ylim))
         maxY=c(maxY,max(factors,na.rm=TRUE))
     if(! missing(densityPar)| ! missing (meanPar)){
-        vals=getNormalizedValues(qs, methods=normMethod("nrpkm"), 
+        vals=getNormalizedValues(qs, methods=normMethod("nrpkm"),
             windows=NULL, samples=sample)[,1]
         cfactors=
             mcols(getRegions(qs))[,paste0(getEnrichmentPattern(qs),"_density")]
-    }    
+    }
     if(!missing(meanPar)){
         breakPoints=(sPoints[-1]+sPoints[-length(sPoints)])/2
         group=findInterval(x=cfactors, vec=breakPoints)
@@ -503,7 +504,7 @@ plotEnrichmentProfile<-function(qs,sample, sPoints=seq(0,30,1),
         maxY=max(c(maxY,means))
     }
     par=getEnrichmentParameters(qs, sample)
-    if(!is.null(par)){        
+    if(!is.null(par)){
         fitted=.sigmF2(sPoints,par[1], par[2], par[3] )+
             getOffset(qs,sample,scale="rpkm")
         maxY=max(c(maxY,fitted))
@@ -525,8 +526,8 @@ plotEnrichmentProfile<-function(qs,sample, sPoints=seq(0,30,1),
         do.call("lines", c(list(x=sPoints[f], y=means[f]),meanPar))
         retList$window_means=means
     }
-    
-    if(!is.null(par)){        
+
+    if(!is.null(par)){
         f=is.finite(sPoints)
         do.call("lines",c(list(x=sPoints[f], y=fitted[f]), fitPar))
         retList$fitted=fitted
@@ -567,13 +568,13 @@ plotEPmatrix<-function(qs, sa=getSampleNames(qs),
         i=i+1
         message(s)
         retList[[s]]=do.call(plotEnrichmentProfile,
-            c(list(qs, s, axes=FALSE, cex.main=2, 
+            c(list(qs, s, axes=FALSE, cex.main=2,
             cfPar=list(col="black", lty=1, lwd=1.5),
-            fitPar=list(col="darkgreen")),param) )    
+            fitPar=list(col="darkgreen")),param) )
         box()
         if(i%%ncol==1) axis(2, cex.axis=1.5)
         if(i>length(sa)-ncol) axis(1, cex.axis=1.5)
-        
+
     }
     par(mfrow=c(1,1))
     invisible(retList)

--- a/man/getPCA.Rd
+++ b/man/getPCA.Rd
@@ -2,13 +2,13 @@
 \alias{getPCA}
 
 \title{Principle Component Analysis (PCA) in QSea}
-\description{The getPCA() function performs a 
-Principle Component Analysis (PCA) of the coverage profiles from a qsea object 
-for exploratory data analysis. 
+\description{The getPCA() function performs a
+Principle Component Analysis (PCA) of the coverage profiles from a qsea object
+for exploratory data analysis.
 }
 \usage{
-getPCA(qs, chr= getChrNames(qs),ROIs, minRowSum=20, keep , 
-    norm_method=normMethod(logRPM = 
+getPCA(qs, chr= getChrNames(qs),ROIs, minRowSum=20, keep ,
+    norm_method=normMethod(logRPM =
     c("log", "library_size", "cnv", "preference", "psC10")), topVar=1000,
     samples=getSampleNames(qs))
 }
@@ -16,22 +16,27 @@ getPCA(qs, chr= getChrNames(qs),ROIs, minRowSum=20, keep ,
 \item{qs}{DIPSset (mandatory)}
 \item{chr}{chromosomes to consider}
 \item{ROIs}{If specified, only windows overlapping ROIs are considered. }
-\item{minRowSum}{minimal number of total read counts per window 
+\item{minRowSum}{minimal number of total read counts per window
         over all samples}
 \item{keep}{windows to consider}
-\item{norm_method}{name of predefined normalization (e.g. "beta"), 
+\item{norm_method}{name of predefined normalization (e.g. "beta"),
         or user defined normalization by calling normMethod() function }
 \item{topVar}{only the top variable windows are considered}
 \item{samples}{names of samples to be considered}
+\item{minEnrichment}{
+    for transformation to absolute methylation level,
+    you can specify the minimal number of expected reads for a fully
+    methylated window. This avoids inaccurate estimates, due to low enrichment.
+}
 
 }
 \details{
-The principle component analysis is calculated using the 
+The principle component analysis is calculated using the
         singular value decomposition (svd).
 }
 \value{
-    getPCA() returns a list object, containing the svd and 
-    information on the selected windows. 
+    getPCA() returns a list object, containing the svd and
+    information on the selected windows.
 }
 
 
@@ -39,7 +44,7 @@ The principle component analysis is calculated using the
 Mathias Lienhard
 }
 \seealso{plotPCA}
-\examples{ 
+\examples{
 qs=getExampleQseaSet( repl=5)
 pca=getPCA(qs, norm_method="beta")
 colors=c(rep("red", 5), rep("green", 5))


### PR DESCRIPTION
This PR fixes the issue #4 with `getPCA` calculating the rowSums on all the samples, not just the ones selected for the PCA itself. 

It also exposes the `minEnrichment` option to the top level. I have set this to the previous default of 0, rather than the 3 that is the default of `makeTable`. Personally I would suggest setting this to be the `makeTable` default, but that will potentially change previous output.